### PR TITLE
GOSSIP-14 Periodically attempt to contact dead members

### DIFF
--- a/src/main/java/org/apache/gossip/manager/ActiveGossipThread.java
+++ b/src/main/java/org/apache/gossip/manager/ActiveGossipThread.java
@@ -45,7 +45,13 @@ abstract public class ActiveGossipThread implements Runnable {
     while (keepRunning.get()) {
       try {
         TimeUnit.MILLISECONDS.sleep(gossipManager.getSettings().getGossipInterval());
+        
+        // contact a live member.
         sendMembershipList(gossipManager.getMyself(), gossipManager.getLiveMembers());
+        
+        // contact a dead member.
+        sendMembershipList(gossipManager.getMyself(), gossipManager.getDeadMembers());
+        
       } catch (InterruptedException e) {
         GossipService.LOGGER.error(e);
         keepRunning.set(false);

--- a/src/main/java/org/apache/gossip/manager/GossipCore.java
+++ b/src/main/java/org/apache/gossip/manager/GossipCore.java
@@ -131,7 +131,7 @@ public class GossipCore {
     if (t == null){
       return null;
     }
-    Future<Response> response = service.submit( new Callable<Response>(){
+    final Future<Response> response = service.submit( new Callable<Response>(){
       @Override
       public Response call() throws Exception {
         while(true){
@@ -156,7 +156,8 @@ public class GossipCore {
       LOGGER.error(e.getMessage(), e);
       return null;
     } catch (TimeoutException e) {
-      LOGGER.error(e.getMessage(), e);
+      boolean cancelled = response.cancel(true);
+      LOGGER.error(String.format("Threadpool timeout attempting to contact %s, cancelled ? %b", uri.toString(), cancelled));
       return null; 
     } finally {
       if (t != null){

--- a/src/main/java/org/apache/gossip/manager/GossipManager.java
+++ b/src/main/java/org/apache/gossip/manager/GossipManager.java
@@ -132,6 +132,21 @@ public abstract class GossipManager extends Thread implements NotificationListen
     return settings;
   }
 
+  // TODO: Use some java 8 goodness for these functions.
+  
+  /**
+   * @return a read only list of members found in the DOWN state.
+   */
+  public List<LocalGossipMember> getDeadMembers() {
+    List<LocalGossipMember> down = new ArrayList<>();
+    for (Entry<LocalGossipMember, GossipState> entry : members.entrySet()) {
+      if (GossipState.DOWN.equals(entry.getValue())) {
+        down.add(entry.getKey());
+      }
+    }
+    return Collections.unmodifiableList(down);
+  }
+
   /**
    * 
    * @return a read only list of members found in the UP state

--- a/src/main/java/org/apache/gossip/manager/random/RandomActiveGossipThread.java
+++ b/src/main/java/org/apache/gossip/manager/random/RandomActiveGossipThread.java
@@ -71,12 +71,16 @@ public class RandomActiveGossipThread extends ActiveGossipThread {
   }
 
   protected void sendMembershipList(LocalGossipMember me, List<LocalGossipMember> memberList) {
-    GossipService.LOGGER.debug("Send sendMembershipList() is called.");
+    
     me.setHeartbeat(System.currentTimeMillis());
     LocalGossipMember member = selectPartner(memberList);
     if (member == null) {
+      GossipService.LOGGER.debug("Send sendMembershipList() is called without action");
       return;
+    } else {
+      GossipService.LOGGER.debug("Send sendMembershipList() is called to " + member.toString());
     }
+    
     try (DatagramSocket socket = new DatagramSocket()) {
       socket.setSoTimeout(gossipManager.getSettings().getGossipInterval());
       UdpActiveGossipMessage message = new UdpActiveGossipMessage();


### PR DESCRIPTION
This bug is a bit of a special case. I'm still getting familiar with the code, but it appears to happen because of the PUSH nature of the detection algorithm, which is basically this: if node A thinks node B is  DOWN, the only way B can be marked UP is if B contacts A. However, with the code as it  is currently written, this never happens because B will only contact nodes it thinks are UP (B thinks A is DOWN).

I think the right way to fix this bug is to figure out how come the states are wrong on the first place, when the nodes first come up. Still digging in.

This PR also does a tiny bit of cleanup:
- cancel the `Future` in `GossipCore` when a timeout happens.
- modify the logging in `RandomActiveGossipThread` to give a clear indication of who (in anybody) is being contacted.
