### PR TITLE
Gossip 15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 # Maven
 log/
 target/
+/bin/

--- a/src/main/java/org/apache/gossip/manager/ActiveGossipThread.java
+++ b/src/main/java/org/apache/gossip/manager/ActiveGossipThread.java
@@ -18,11 +18,11 @@
 package org.apache.gossip.manager;
 
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import static java.util.concurrent.TimeUnit.*;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.apache.gossip.GossipService;
 import org.apache.gossip.LocalGossipMember;
 
 /**
@@ -30,34 +30,43 @@ import org.apache.gossip.LocalGossipMember;
  * list. This information is important to maintaining a common state among all the nodes, and is
  * important for detecting failures.
  */
-abstract public class ActiveGossipThread implements Callable<Boolean> {
+abstract public class ActiveGossipThread implements Runnable, Shutdownable {
 
   protected final GossipManager gossipManager;
 
   private final AtomicBoolean keepRunning;
+  
+  protected final int interval;
+  
+  protected final ScheduledExecutorService self; 
+  
+  protected CountDownLatch gate;
 
-  public ActiveGossipThread(GossipManager gossipManager) {
+  public ActiveGossipThread(GossipManager gossipManager, CountDownLatch gate) {
     this.gossipManager = gossipManager;
     this.keepRunning = new AtomicBoolean(true);
+    this.interval = gossipManager.getSettings().getGossipInterval();
+    this.self = Executors.newSingleThreadScheduledExecutor();
+    this.gate = gate;
+  }
+  
+  public void start() {
+    this.self.scheduleAtFixedRate(this, 0, interval, MILLISECONDS);
   }
 
   @Override
-  public Boolean call() throws Exception {
+  public void run() {
     while (keepRunning.get()) {
-      try {
-        TimeUnit.MILLISECONDS.sleep(gossipManager.getSettings().getGossipInterval());
-        sendMembershipList(gossipManager.getMyself(), gossipManager.getMemberList());
-      } catch (InterruptedException e) {
-        GossipService.LOGGER.error(e);
-        keepRunning.set(false);
-      }
+      sendMembershipList(gossipManager.getMyself(), gossipManager.getMemberList());
     }
     shutdown();
-    return keepRunning.get();
   }
 
+  @Override 
   public void shutdown() {
     keepRunning.set(false);
+    this.self.shutdown();
+    this.gate.countDown();
   }
 
   /**

--- a/src/main/java/org/apache/gossip/manager/ActiveGossipThread.java
+++ b/src/main/java/org/apache/gossip/manager/ActiveGossipThread.java
@@ -18,6 +18,7 @@
 package org.apache.gossip.manager;
 
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -29,7 +30,7 @@ import org.apache.gossip.LocalGossipMember;
  * list. This information is important to maintaining a common state among all the nodes, and is
  * important for detecting failures.
  */
-abstract public class ActiveGossipThread implements Runnable {
+abstract public class ActiveGossipThread implements Callable<Boolean> {
 
   protected final GossipManager gossipManager;
 
@@ -41,7 +42,7 @@ abstract public class ActiveGossipThread implements Runnable {
   }
 
   @Override
-  public void run() {
+  public Boolean call() throws Exception {
     while (keepRunning.get()) {
       try {
         TimeUnit.MILLISECONDS.sleep(gossipManager.getSettings().getGossipInterval());
@@ -52,6 +53,7 @@ abstract public class ActiveGossipThread implements Runnable {
       }
     }
     shutdown();
+    return keepRunning.get();
   }
 
   public void shutdown() {

--- a/src/main/java/org/apache/gossip/manager/GossipManager.java
+++ b/src/main/java/org/apache/gossip/manager/GossipManager.java
@@ -17,24 +17,22 @@
  */
 package org.apache.gossip.manager;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import javax.management.Notification;
 import javax.management.NotificationListener;
-
 import org.apache.log4j.Logger;
-
 import org.apache.gossip.GossipMember;
 import org.apache.gossip.GossipService;
 import org.apache.gossip.GossipSettings;
@@ -44,7 +42,7 @@ import org.apache.gossip.event.GossipState;
 import org.apache.gossip.manager.impl.OnlyProcessReceivedPassiveGossipThread;
 import org.apache.gossip.manager.random.RandomActiveGossipThread;
 
-public abstract class GossipManager implements Callable<Boolean>, NotificationListener {
+public abstract class GossipManager extends Thread implements  NotificationListener {
 
   public static final Logger LOGGER = Logger.getLogger(GossipManager.class);
 
@@ -59,31 +57,22 @@ public abstract class GossipManager implements Callable<Boolean>, NotificationLi
   private final AtomicBoolean gossipServiceRunning;
 
   private final GossipListener listener;
+  
+  protected final ServiceFactory serviceFactory;
 
-  private ActiveGossipThread activeGossipThread;
-
-  private PassiveGossipThread passiveGossipThread;
+  protected ServiceBundle bundle;
 
   private ExecutorService gossipThreadExecutor;
   
   private GossipCore gossipCore;
-  
-  protected final String name;
 
-
-  public GossipManager(String cluster,
-          URI uri, String id, GossipSettings settings,
-          List<GossipMember> gossipMembers, GossipListener listener) {
-    this("default-gossip-manager", cluster, uri, id, settings, gossipMembers, listener);
-  }
-
-  public GossipManager(String name, String cluster, URI uri, String id, 
+  public GossipManager(String cluster, URI uri, String id, 
 		               GossipSettings settings, 
 		               List<GossipMember> gossipMembers, 
 		               GossipListener listener) {
-    this.name = name;
     this.settings = settings;
     this.gossipCore = new GossipCore(this);
+    this.serviceFactory = new ServiceFactory(this, gossipCore);
     me = new LocalGossipMember(cluster, uri, id, System.currentTimeMillis(), this,
             settings.getCleanupInterval());
     members = new ConcurrentSkipListMap<>();
@@ -104,10 +93,6 @@ public abstract class GossipManager implements Callable<Boolean>, NotificationLi
         GossipService.LOGGER.debug("Service has been shutdown...");
       }
     }));
-  }
-  
-  public String getName() {
-	return this.name;
   }
 
   /**
@@ -181,24 +166,24 @@ public abstract class GossipManager implements Callable<Boolean>, NotificationLi
    * thread and start the receiver thread.
    */
   @Override 
-  public Boolean call() throws Exception {
+  public void run() {
     for (LocalGossipMember member : members.keySet()) {
       if (member != me) {
         member.startTimeoutTimer();
       }
     }
-    passiveGossipThread = new OnlyProcessReceivedPassiveGossipThread(this, gossipCore);
-    final Future<Boolean> passiveThreadFuture = gossipThreadExecutor.submit(passiveGossipThread);
-    activeGossipThread = new RandomActiveGossipThread(this, this.gossipCore);
-    final Future<Boolean> activeThreadFuture = gossipThreadExecutor.submit(activeGossipThread);
-    GossipService.LOGGER.debug("The GossipService is started.");
-    Boolean passiveThreadResult = passiveThreadFuture.get();
-    if(LOGGER.isDebugEnabled())
-      LOGGER.debug("Passive thread returns "+passiveThreadResult);
-    Boolean activeThreadResult = activeThreadFuture.get();
-    if(LOGGER.isDebugEnabled())
-      LOGGER.debug("Active thread returns "+activeThreadResult);
-    return gossipServiceRunning.get();
+    final List<Class<? extends Runnable>> services = new ArrayList<>();
+    services.add(OnlyProcessReceivedPassiveGossipThread.class);
+    services.add(RandomActiveGossipThread.class);
+    this.bundle = serviceFactory.newServices(services);
+    for(Runnable service: this.bundle.services()) {
+      gossipThreadExecutor.submit(service);
+    }
+    try {
+      this.bundle.guard().await();
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();	
+    }
   }
 
   /**
@@ -208,11 +193,12 @@ public abstract class GossipManager implements Callable<Boolean>, NotificationLi
     gossipServiceRunning.set(false);
     gossipThreadExecutor.shutdown();
     gossipCore.shutdown();
-    if (passiveGossipThread != null) {
-      passiveGossipThread.shutdown();
-    }
-    if (activeGossipThread != null) {
-      activeGossipThread.shutdown();
+    if(null != this.bundle) {
+      for(Runnable runnable: this.bundle.services()) {
+    	if(runnable instanceof Shutdownable) {
+    	  ((Shutdownable) runnable).shutdown();
+    	}
+      }
     }
     try {
       boolean result = gossipThreadExecutor.awaitTermination(1000, TimeUnit.MILLISECONDS);
@@ -223,4 +209,60 @@ public abstract class GossipManager implements Callable<Boolean>, NotificationLi
       LOGGER.error(e);
     }
   }
+}
+class ServiceFactory {
+	
+  final Logger LOGGER = Logger.getLogger(ServiceFactory.class);
+
+  final GossipManager manager;
+  final GossipCore core;
+
+  ServiceFactory(GossipManager manager, GossipCore core) {
+    this.manager = manager;
+    this.core = core;
+  }
+  
+  ServiceBundle newServices(List<Class<? extends Runnable>> classes) {
+	final CountDownLatch gate = new CountDownLatch(classes.size());
+	final List<Runnable> services = new ArrayList<>();
+	try {
+	  for(Class<? extends Runnable> klz: classes) {
+        final Constructor<? extends Runnable> constructor = 
+           klz.getDeclaredConstructor(GossipManager.class, GossipCore.class, 
+        		                      CountDownLatch.class);
+        final Runnable thread = constructor.newInstance(manager, core, gate);
+        services.add(thread);
+	  }
+    } catch (IllegalAccessException iae) {
+      LOGGER.error("Can't access to the definition of classes ...", iae);
+    } catch (InstantiationException ie) {
+      LOGGER.error("Can't instantiate classes ...", ie);
+    } catch (InvocationTargetException ite) {
+      LOGGER.error("Can't invoke target exception ...", ite);
+    } catch (NoSuchMethodException nsme) {
+      LOGGER.error("Method not found ...", nsme);
+    }
+	return new ServiceBundle(services, gate);
+  }
+  
+}
+
+class ServiceBundle {
+	
+  final List<Runnable> runnables;
+  final CountDownLatch gate;
+
+  ServiceBundle(List<Runnable> services, CountDownLatch gate) {
+	this.runnables = services;  
+	this.gate = gate;
+  }
+  
+  List<Runnable> services() {
+	return Collections.unmodifiableList(runnables);
+  }
+  
+  CountDownLatch guard() {
+	return gate;  
+  }
+
 }

--- a/src/main/java/org/apache/gossip/manager/PassiveGossipThread.java
+++ b/src/main/java/org/apache/gossip/manager/PassiveGossipThread.java
@@ -24,6 +24,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.SocketException;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.gossip.GossipMember;
@@ -39,7 +40,7 @@ import org.apache.gossip.RemoteGossipMember;
  * membership list, but if you choose to gossip additional information, you will need some logic to
  * determine the incoming message.
  */
-abstract public class PassiveGossipThread implements Runnable {
+abstract public class PassiveGossipThread implements Callable<Boolean> {
 
   public static final Logger LOGGER = Logger.getLogger(PassiveGossipThread.class);
 
@@ -75,7 +76,7 @@ abstract public class PassiveGossipThread implements Runnable {
   }
 
   @Override
-  public void run() {
+  public Boolean call() throws Exception {
     while (keepRunning.get()) {
       try {
         byte[] buf = new byte[server.getReceiveBufferSize()];
@@ -104,6 +105,7 @@ abstract public class PassiveGossipThread implements Runnable {
       }
     }
     shutdown();
+    return keepRunning.get();
   }
 
   private void debug(int packetLength, byte[] jsonBytes) {

--- a/src/main/java/org/apache/gossip/manager/Shutdownable.java
+++ b/src/main/java/org/apache/gossip/manager/Shutdownable.java
@@ -1,0 +1,5 @@
+package org.apache.gossip.manager;
+
+public interface Shutdownable {
+  void shutdown();
+}

--- a/src/main/java/org/apache/gossip/manager/impl/OnlyProcessReceivedPassiveGossipThread.java
+++ b/src/main/java/org/apache/gossip/manager/impl/OnlyProcessReceivedPassiveGossipThread.java
@@ -18,7 +18,7 @@
 package org.apache.gossip.manager.impl;
 
 import java.util.List;
-
+import java.util.concurrent.CountDownLatch;
 import org.apache.gossip.GossipMember;
 import org.apache.gossip.LocalGossipMember;
 import org.apache.gossip.RemoteGossipMember;
@@ -31,8 +31,10 @@ public class OnlyProcessReceivedPassiveGossipThread extends PassiveGossipThread 
   
   public static final Logger LOGGER = Logger.getLogger(OnlyProcessReceivedPassiveGossipThread.class);
 
-  public OnlyProcessReceivedPassiveGossipThread(GossipManager gossipManager, GossipCore gossipCore) {
-    super(gossipManager, gossipCore);
+  public OnlyProcessReceivedPassiveGossipThread(GossipManager gossipManager, 
+		                                        GossipCore gossipCore,
+		                                        CountDownLatch gate) {
+    super(gossipManager, gossipCore, gate);
   }
 
   /**

--- a/src/main/java/org/apache/gossip/manager/random/RandomActiveGossipThread.java
+++ b/src/main/java/org/apache/gossip/manager/random/RandomActiveGossipThread.java
@@ -22,7 +22,7 @@ import java.net.DatagramSocket;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID; 
-
+import java.util.concurrent.CountDownLatch;
 import org.apache.gossip.GossipService;
 import org.apache.gossip.LocalGossipMember;
 import org.apache.gossip.manager.ActiveGossipThread;
@@ -44,8 +44,10 @@ public class RandomActiveGossipThread extends ActiveGossipThread {
   private final Random random;
   private final GossipCore gossipCore;
 
-  public RandomActiveGossipThread(GossipManager gossipManager, GossipCore gossipCore) {
-    super(gossipManager);
+  public RandomActiveGossipThread(GossipManager gossipManager, 
+		                          GossipCore gossipCore, 
+		                          CountDownLatch gate) {
+    super(gossipManager, gate);
     random = new Random();
     this.gossipCore = gossipCore;
   }

--- a/src/main/java/org/apache/gossip/manager/random/RandomActiveGossipThread.java
+++ b/src/main/java/org/apache/gossip/manager/random/RandomActiveGossipThread.java
@@ -19,11 +19,9 @@ package org.apache.gossip.manager.random;
 
 import java.io.IOException;
 import java.net.DatagramSocket;
-import java.net.InetAddress;
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Random;
-import java.util.UUID;
+import java.util.UUID; 
 
 import org.apache.gossip.GossipService;
 import org.apache.gossip.LocalGossipMember;

--- a/src/main/java/org/apache/gossip/manager/random/RandomGossipManager.java
+++ b/src/main/java/org/apache/gossip/manager/random/RandomGossipManager.java
@@ -21,7 +21,6 @@ import org.apache.gossip.GossipMember;
 import org.apache.gossip.GossipSettings;
 import org.apache.gossip.event.GossipListener;
 import org.apache.gossip.manager.GossipManager;
-import org.apache.gossip.manager.impl.OnlyProcessReceivedPassiveGossipThread;
 
 import java.net.URI;
 import java.util.List;

--- a/src/test/java/org/apache/gossip/ShutdownDeadtimeTest.java
+++ b/src/test/java/org/apache/gossip/ShutdownDeadtimeTest.java
@@ -130,10 +130,11 @@ public class ShutdownDeadtimeTest {
                   total += clients.get(i).get_gossipManager().getMemberList().size();
               }
               return total;
-          }}).afterWaitingAtMost(20, TimeUnit.SECONDS).isEqualTo(20);
+          }}).afterWaitingAtMost(40, TimeUnit.SECONDS).isEqualTo(20);
       
       for (int i = 0; i < clusterMembers; ++i) {
         clients.get(i).shutdown();
       }
   }
 }
+

--- a/src/test/java/org/apache/gossip/ShutdownDeadtimeTest.java
+++ b/src/test/java/org/apache/gossip/ShutdownDeadtimeTest.java
@@ -130,11 +130,10 @@ public class ShutdownDeadtimeTest {
                   total += clients.get(i).get_gossipManager().getMemberList().size();
               }
               return total;
-          }}).afterWaitingAtMost(40, TimeUnit.SECONDS).isEqualTo(20);
+          }}).afterWaitingAtMost(20, TimeUnit.SECONDS).isEqualTo(20);
       
       for (int i = 0; i < clusterMembers; ++i) {
         clients.get(i).shutdown();
       }
   }
 }
-


### PR DESCRIPTION
Based on [1], the primary change contains 
- replace timeunit.milliseconds.sleep within active gossip thread with scheduled service executor.
- use count down latch for active/ passive gossip thread harness.

[1]. https://github.com/chlin501/incubator-gossip/commit/0a7d2ee12e54cdd4ccc171ea89ddb41af8b380e4
