### PR TITLE
GOSSIP-79 Isolate UDP and JSON code

### DIFF
--- a/gossip-base/src/main/java/org/apache/gossip/GossipSettings.java
+++ b/gossip-base/src/main/java/org/apache/gossip/GossipSettings.java
@@ -45,6 +45,9 @@ public class GossipSettings {
   
   private String activeGossipClass = "org.apache.gossip.manager.SimpleActiveGossipper";
   
+  private String transportManagerClass = "org.apache.gossip.transport.UdpTransportManager";
+  private String protocolManagerClass = "org.apache.gossip.protocol.JacksonProtocolManager";
+  
   private Map<String,String> activeGossipProperties = new HashMap<>();
   
   private String pathToRingState = "./";
@@ -222,5 +225,12 @@ public class GossipSettings {
   public void setSignMessages(boolean signMessages) {
     this.signMessages = signMessages;
   }
-  
+
+  public String getTransportManagerClass() {
+    return transportManagerClass;
+  }
+
+  public String getProtocolManagerClass() {
+    return protocolManagerClass;
+  }
 }

--- a/gossip-base/src/main/java/org/apache/gossip/manager/GossipManagerBuilder.java
+++ b/gossip-base/src/main/java/org/apache/gossip/manager/GossipManagerBuilder.java
@@ -18,12 +18,9 @@
 package org.apache.gossip.manager;
 
 import com.codahale.metrics.MetricRegistry;
-import com.fasterxml.jackson.core.JsonGenerator.Feature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.gossip.Member;
 import org.apache.gossip.GossipSettings;
 import org.apache.gossip.StartupSettings;
-import org.apache.gossip.crdt.CrdtModule;
 import org.apache.gossip.event.GossipListener;
 import org.apache.gossip.manager.handlers.MessageHandler;
 import org.apache.gossip.manager.handlers.MessageHandlerFactory;
@@ -49,7 +46,6 @@ public class GossipManagerBuilder {
     private GossipListener listener;
     private MetricRegistry registry;
     private Map<String,String> properties;
-    private ObjectMapper objectMapper;
     private MessageHandler messageHandler;
 
     private ManagerBuilder() {}
@@ -108,11 +104,6 @@ public class GossipManagerBuilder {
       this.uri = uri;
       return this;
     }
-    
-    public ManagerBuilder mapper(ObjectMapper objectMapper){
-      this.objectMapper = objectMapper;
-      return this;
-    }
 
     public ManagerBuilder messageHandler(MessageHandler messageHandler) {
       this.messageHandler = messageHandler;
@@ -136,16 +127,11 @@ public class GossipManagerBuilder {
       if (gossipMembers == null) {
         gossipMembers = new ArrayList<>();
       }
-      if (objectMapper == null) {
-        objectMapper = new ObjectMapper();
-        objectMapper.enableDefaultTyping();
-        objectMapper.registerModule(new CrdtModule());
-        objectMapper.configure(Feature.WRITE_NUMBERS_AS_STRINGS, false);
-      }
+      
       if (messageHandler == null) {
         messageHandler = MessageHandlerFactory.defaultHandler();
-      } 
-      return new GossipManager(cluster, uri, id, properties, settings, gossipMembers, listener, registry, objectMapper, messageHandler) {} ;
+      }
+      return new GossipManager(cluster, uri, id, properties, settings, gossipMembers, listener, registry, messageHandler) {} ;
     }
   }
 

--- a/gossip-base/src/main/java/org/apache/gossip/protocol/JacksonProtocolManager.java
+++ b/gossip-base/src/main/java/org/apache/gossip/protocol/JacksonProtocolManager.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gossip.protocol;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.gossip.GossipSettings;
+import org.apache.gossip.crdt.CrdtModule;
+import org.apache.gossip.manager.PassiveGossipConstants;
+import org.apache.gossip.model.Base;
+import org.apache.gossip.model.SignedPayload;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.PrivateKey;
+import java.security.Signature;
+import java.security.SignatureException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+
+// this class is constructed by reflection in GossipManager.
+public class JacksonProtocolManager implements ProtocolManager {
+  
+  private final ObjectMapper objectMapper;
+  private final PrivateKey privKey;
+  private final Meter signed;
+  private final Meter unsigned;
+  
+  /** required for reflection to work! */
+  public JacksonProtocolManager(GossipSettings settings, String id, MetricRegistry registry) {
+    // set up object mapper.
+    objectMapper = buildObjectMapper(settings);
+    
+    // set up message signing.
+    if (settings.isSignMessages()){
+      File privateKey = new File(settings.getPathToKeyStore(), id);
+      File publicKey = new File(settings.getPathToKeyStore(), id + ".pub");
+      if (!privateKey.exists()){
+        throw new IllegalArgumentException("private key not found " + privateKey);
+      }
+      if (!publicKey.exists()){
+        throw new IllegalArgumentException("public key not found " + publicKey);
+      }
+      try (FileInputStream keyfis = new FileInputStream(privateKey)) {
+        byte[] encKey = new byte[keyfis.available()];
+        keyfis.read(encKey);
+        keyfis.close();
+        PKCS8EncodedKeySpec privKeySpec = new PKCS8EncodedKeySpec(encKey);
+        KeyFactory keyFactory = KeyFactory.getInstance("DSA");
+        privKey = keyFactory.generatePrivate(privKeySpec);
+      } catch (NoSuchAlgorithmException | InvalidKeySpecException | IOException e) {
+        throw new RuntimeException("failed hard", e);
+      }
+    } else {
+      privKey = null;
+    }
+    
+    signed = registry.meter(PassiveGossipConstants.SIGNED_MESSAGE);
+    unsigned = registry.meter(PassiveGossipConstants.UNSIGNED_MESSAGE);
+  }
+
+  @Override
+  public byte[] write(Base message) throws IOException {
+    byte[] json_bytes;
+    if (privKey == null){
+      json_bytes = objectMapper.writeValueAsBytes(message);
+    } else {
+      SignedPayload p = new SignedPayload();
+      p.setData(objectMapper.writeValueAsString(message).getBytes());
+      p.setSignature(sign(p.getData(), privKey));
+      json_bytes = objectMapper.writeValueAsBytes(p);
+    }
+    return json_bytes;
+  }
+
+  @Override
+  public Base read(byte[] buf) throws IOException {
+    Base activeGossipMessage = objectMapper.readValue(buf, Base.class);
+    if (activeGossipMessage instanceof SignedPayload){
+      SignedPayload s = (SignedPayload) activeGossipMessage;
+      signed.mark();
+      return objectMapper.readValue(s.getData(), Base.class);
+    } else {
+      unsigned.mark();
+      return activeGossipMessage;
+    }
+  }
+
+  public static ObjectMapper buildObjectMapper(GossipSettings settings) {
+    ObjectMapper om = new ObjectMapper();
+    om.enableDefaultTyping();
+    // todo: should be specified in the configuration.
+    om.registerModule(new CrdtModule());
+    om.configure(JsonGenerator.Feature.WRITE_NUMBERS_AS_STRINGS, false);
+    return om;
+  }
+  
+  private static byte[] sign(byte [] bytes, PrivateKey pk){
+    Signature dsa;
+    try {
+      dsa = Signature.getInstance("SHA1withDSA", "SUN");
+      dsa.initSign(pk);
+      dsa.update(bytes);
+      return dsa.sign();
+    } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidKeyException | SignatureException e) {
+      throw new RuntimeException(e);
+    } 
+  }
+}

--- a/gossip-base/src/main/java/org/apache/gossip/protocol/ProtocolManager.java
+++ b/gossip-base/src/main/java/org/apache/gossip/protocol/ProtocolManager.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gossip.protocol;
+
+import org.apache.gossip.model.Base;
+
+import java.io.IOException;
+
+/** interface for managing message marshaling. */
+public interface ProtocolManager {
+
+  /** serialize a message
+   * @param message
+   * @return serialized message.
+   * @throws IOException
+   */
+  byte[] write(Base message) throws IOException;
+
+  /**
+   * Reads the next message from a byte source.
+   * @param buf
+   * @return a gossip message.
+   * @throws IOException
+   */
+  Base read(byte[] buf) throws IOException;
+}

--- a/gossip-base/src/main/java/org/apache/gossip/transport/AbstractTransportManager.java
+++ b/gossip-base/src/main/java/org/apache/gossip/transport/AbstractTransportManager.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gossip.transport;
+
+import com.codahale.metrics.MetricRegistry;
+import org.apache.gossip.manager.AbstractActiveGossiper;
+import org.apache.gossip.manager.GossipCore;
+import org.apache.gossip.manager.GossipManager;
+import org.apache.gossip.manager.PassiveGossipThread;
+import org.apache.gossip.utils.ReflectionUtils;
+import org.apache.log4j.Logger;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Manage the protcol threads (active and passive gossipers).
+ */
+public abstract class AbstractTransportManager implements TransportManager {
+  
+  public static final Logger LOGGER = Logger.getLogger(AbstractTransportManager.class);
+  
+  private final PassiveGossipThread passiveGossipThread;
+  private final ExecutorService gossipThreadExecutor;
+  
+  private final AbstractActiveGossiper activeGossipThread;
+  
+  public AbstractTransportManager(GossipManager gossipManager, GossipCore gossipCore) {
+    
+    passiveGossipThread = new PassiveGossipThread(gossipManager, gossipCore);
+    gossipThreadExecutor = Executors.newCachedThreadPool();
+    activeGossipThread = ReflectionUtils.constructWithReflection(
+      gossipManager.getSettings().getActiveGossipClass(),
+        new Class<?>[]{
+            GossipManager.class, GossipCore.class, MetricRegistry.class
+        },
+        new Object[]{
+            gossipManager, gossipCore, gossipManager.getRegistry()
+        });
+  }
+
+  // shut down threads etc.
+  @Override
+  public void shutdown() {
+    passiveGossipThread.requestStop();
+    gossipThreadExecutor.shutdown();
+    if (activeGossipThread != null) {
+      activeGossipThread.shutdown();
+    }
+    try {
+      boolean result = gossipThreadExecutor.awaitTermination(10, TimeUnit.MILLISECONDS);
+      if (!result) {
+        LOGGER.error("executor shutdown timed out");
+      }
+    } catch (InterruptedException e) {
+      LOGGER.error(e);
+    }
+    gossipThreadExecutor.shutdownNow();
+  }
+
+  @Override
+  public void startActiveGossiper() {
+    activeGossipThread.init(); 
+  }
+
+  @Override
+  public void startEndpoint() {
+    gossipThreadExecutor.execute(passiveGossipThread);
+  }
+}

--- a/gossip-base/src/main/java/org/apache/gossip/transport/TransportManager.java
+++ b/gossip-base/src/main/java/org/apache/gossip/transport/TransportManager.java
@@ -15,19 +15,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gossip.manager.impl;
+package org.apache.gossip.transport;
 
-import org.apache.gossip.manager.GossipCore;
-import org.apache.gossip.manager.GossipManager;
-import org.apache.gossip.manager.PassiveGossipThread;
-import org.apache.log4j.Logger;
+import java.io.IOException;
+import java.net.URI;
 
-public class OnlyProcessReceivedPassiveGossipThread extends PassiveGossipThread {
+/** interface for manage that sends and receives messages that have already been serialized. */
+public interface TransportManager {
   
-  public static final Logger LOGGER = Logger.getLogger(OnlyProcessReceivedPassiveGossipThread.class);
-
-  public OnlyProcessReceivedPassiveGossipThread(GossipManager gossipManager, GossipCore gossipCore) {
-    super(gossipManager, gossipCore);
-  }
-
+  /** starts the active gossip thread responsible for reaching out to remote nodes. Not related to `startEndpoint()` */
+  void startActiveGossiper();
+  
+  /** starts the passive gossip thread that receives messages from remote nodes. Not related to `startActiveGossiper()` */
+  void startEndpoint();
+  
+  /** attempts to shutdown all threads. */
+  void shutdown();
+  
+  /** sends a payload to an endpoint. */
+  void send(URI endpoint, byte[] buf) throws IOException;
+  
+  /** gets the next payload being sent to this node */
+  byte[] read() throws IOException;
 }

--- a/gossip-base/src/main/java/org/apache/gossip/transport/UdpTransportManager.java
+++ b/gossip-base/src/main/java/org/apache/gossip/transport/UdpTransportManager.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gossip.transport;
+
+import org.apache.gossip.manager.GossipCore;
+import org.apache.gossip.manager.GossipManager;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.net.URI;
+
+/**
+ * This class is constructed by reflection in GossipManager.
+ * It manages transport (byte read/write) operations over UDP.
+ */
+public class UdpTransportManager extends AbstractTransportManager {
+  
+  public static final Logger LOGGER = Logger.getLogger(UdpTransportManager.class);
+  
+  /** The socket used for the passive thread of the gossip service. */
+  private final DatagramSocket server;
+  
+  private final int soTimeout;
+  
+  /** required for reflection to work! */
+  public UdpTransportManager(GossipManager gossipManager, GossipCore gossipCore) {
+    super(gossipManager, gossipCore);
+    
+    soTimeout = gossipManager.getSettings().getGossipInterval() * 2;
+    
+    try {
+      SocketAddress socketAddress = new InetSocketAddress(gossipManager.getMyself().getUri().getHost(),
+              gossipManager.getMyself().getUri().getPort());
+      server = new DatagramSocket(socketAddress);
+    } catch (SocketException ex) {
+      LOGGER.warn(ex);
+      throw new RuntimeException(ex);
+    }
+  }
+
+  @Override
+  public void shutdown() {
+    server.close();
+    super.shutdown();
+  }
+
+  /**
+   * blocking read a message.
+   * @return buffer of message contents.
+   * @throws IOException
+   */
+  public byte[] read() throws IOException {
+    byte[] buf = new byte[server.getReceiveBufferSize()];
+    DatagramPacket p = new DatagramPacket(buf, buf.length);
+    server.receive(p);
+    debug(p.getData());
+    return p.getData();
+  }
+
+  @Override
+  public void send(URI endpoint, byte[] buf) throws IOException {
+    DatagramSocket socket = new DatagramSocket();
+    socket.setSoTimeout(soTimeout);
+    InetAddress dest = InetAddress.getByName(endpoint.getHost());
+    DatagramPacket payload = new DatagramPacket(buf, buf.length, dest, endpoint.getPort());
+    socket.send(payload);
+    // todo: investigate UDP socket reuse. It would save a little setup/teardown time wrt to the local socket.
+    socket.close();
+  }
+  
+  private void debug(byte[] jsonBytes) {
+    if (LOGGER.isDebugEnabled()){
+      String receivedMessage = new String(jsonBytes);
+      LOGGER.debug("Received message ( bytes): " + receivedMessage);
+    }
+  }
+}

--- a/gossip-base/src/main/java/org/apache/gossip/utils/ReflectionUtils.java
+++ b/gossip-base/src/main/java/org/apache/gossip/utils/ReflectionUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gossip.utils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+public class ReflectionUtils {
+
+  /**
+   * Create an instance of a thing. This method essentially makes code more readable by handing the various exception
+   * trapping.
+   * @param className
+   * @param constructorTypes
+   * @param constructorArgs
+   * @param <T>
+   * @return constructed instance of a thing.
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> T constructWithReflection(String className, Class<?>[] constructorTypes, Object[] constructorArgs) {
+    try {
+      Constructor<?> c = Class.forName(className).getConstructor(constructorTypes);
+      c.setAccessible(true);
+      return (T) c.newInstance(constructorArgs);
+    } catch (InvocationTargetException e) {
+      // catch ITE and throw the target if it is a RTE.
+      if (e.getTargetException() != null && RuntimeException.class.isAssignableFrom(e.getTargetException().getClass())) {
+        throw (RuntimeException) e.getTargetException();
+      } else {
+        throw new RuntimeException(e);
+      }
+    } catch (ReflectiveOperationException others) {
+      // Note: No class in the above list should be a descendent of RuntimeException. Otherwise, we're just wrapping
+      //       and making stack traces confusing.
+      throw new RuntimeException(others);
+    }
+  }
+}

--- a/gossip-base/src/test/java/org/apache/gossip/crdt/OrSetTest.java
+++ b/gossip-base/src/test/java/org/apache/gossip/crdt/OrSetTest.java
@@ -18,15 +18,14 @@
 package org.apache.gossip.crdt;
 
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.gossip.GossipSettings;
-import org.apache.gossip.manager.GossipManager;
-import org.apache.gossip.manager.GossipManagerBuilder;
+import org.apache.gossip.protocol.JacksonProtocolManager;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -88,16 +87,11 @@ public class OrSetTest {
   
   @Test
   public void serialTest() throws InterruptedException, URISyntaxException, IOException {
-    GossipManager gossipService2 = GossipManagerBuilder.newBuilder()
-            .cluster("a")
-            .uri(new URI("udp://" + "127.0.0.1" + ":" + (29000 + 1)))
-            .id("1")
-            .gossipSettings(new GossipSettings())
-            .build();
+    ObjectMapper objectMapper = JacksonProtocolManager.buildObjectMapper(new GossipSettings());
     OrSet<Integer> i = new OrSet<Integer>(new OrSet.Builder<Integer>().add(1).remove(1));
-    String s = gossipService2.getObjectMapper().writeValueAsString(i);
+    String s = objectMapper.writeValueAsString(i);
     @SuppressWarnings("unchecked")
-    OrSet<Integer> back = gossipService2.getObjectMapper().readValue(s, OrSet.class);
+    OrSet<Integer> back = objectMapper.readValue(s, OrSet.class);
     Assert.assertEquals(back, i);
   }
   

--- a/gossip-base/src/test/java/org/apache/gossip/manager/GossipManagerBuilderTest.java
+++ b/gossip-base/src/test/java/org/apache/gossip/manager/GossipManagerBuilderTest.java
@@ -25,6 +25,7 @@ import org.apache.gossip.manager.handlers.MessageHandler;
 import org.apache.gossip.manager.handlers.ResponseHandler;
 import org.apache.gossip.manager.handlers.TypedMessageHandler;
 import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
@@ -43,6 +44,17 @@ import static org.junit.jupiter.api.Assertions.expectThrows;
 @RunWith(JUnitPlatform.class)
 public class GossipManagerBuilderTest {
 
+  private GossipManagerBuilder.ManagerBuilder builder;
+  
+  @BeforeEach
+  public void setup() throws Exception {
+    builder = GossipManagerBuilder.newBuilder()
+        .id("id")
+        .cluster("aCluster")
+        .uri(new URI("udp://localhost:2000"))
+        .gossipSettings(new GossipSettings());
+  }
+  
   @Test
   public void idShouldNotBeNull() {
     expectThrows(IllegalArgumentException.class,() -> {
@@ -66,35 +78,20 @@ public class GossipManagerBuilderTest {
   
   @Test
   public void createMembersListIfNull() throws URISyntaxException {
-    GossipManager gossipManager = GossipManagerBuilder.newBuilder()
-        .id("id")
-        .cluster("aCluster")
-        .uri(new URI("udp://localhost:2000"))
-        .gossipSettings(new GossipSettings())
-        .gossipMembers(null).registry(new MetricRegistry()).build();
+    GossipManager gossipManager = builder.gossipMembers(null).registry(new MetricRegistry()).build();
     assertNotNull(gossipManager.getLiveMembers());
   }
 
   @Test
   public void createDefaultMessageHandlerIfNull() throws URISyntaxException {
-    GossipManager gossipManager = GossipManagerBuilder.newBuilder()
-        .id("id")
-        .cluster("aCluster")
-        .uri(new URI("udp://localhost:2000"))
-        .gossipSettings(new GossipSettings())
-        .messageHandler(null).registry(new MetricRegistry()).build();
+    GossipManager gossipManager = builder.messageHandler(null).registry(new MetricRegistry()).build();
     assertNotNull(gossipManager.getMessageHandler());
   }
 
   @Test
   public void testMessageHandlerKeeping() throws URISyntaxException {
     MessageHandler mi = new TypedMessageHandler(Response.class, new ResponseHandler());
-    GossipManager gossipManager = GossipManagerBuilder.newBuilder()
-        .id("id")
-        .cluster("aCluster")
-        .uri(new URI("udp://localhost:2000"))
-        .gossipSettings(new GossipSettings())
-        .messageHandler(mi).registry(new MetricRegistry()).build();
+    GossipManager gossipManager = builder.messageHandler(mi).registry(new MetricRegistry()).build();
     assertNotNull(gossipManager.getMessageHandler());
     Assert.assertEquals(gossipManager.getMessageHandler(), mi);
   }
@@ -106,10 +103,7 @@ public class GossipManagerBuilderTest {
             System.nanoTime(), new HashMap<String, String>(), 1000, 1, "exponential");
     List<Member> memberList = new ArrayList<>();
     memberList.add(member);
-    GossipManager gossipManager = GossipManagerBuilder.newBuilder()
-        .id("id")
-        .cluster("aCluster")
-        .gossipSettings(new GossipSettings())
+    GossipManager gossipManager = builder
         .uri(new URI("udp://localhost:8000"))
         .gossipMembers(memberList).registry(new MetricRegistry()).build();
     assertEquals(1, gossipManager.getDeadMembers().size());

--- a/gossip-base/src/test/java/org/apache/gossip/manager/RingPersistenceTest.java
+++ b/gossip-base/src/test/java/org/apache/gossip/manager/RingPersistenceTest.java
@@ -49,7 +49,7 @@ public class RingPersistenceTest {
                             new RemoteMember("a", new URI("udp://" + "127.0.0.1" + ":" + (29000 + 0)), "0"),
                             new RemoteMember("a", new URI("udp://" + "127.0.0.1" + ":" + (29000 + 2)), "2"))).build();
     gossipService.getRingState().writeToDisk();
-    return gossipService.getRingState().computeTarget();
+    return GossipManager.buildRingStatePath(gossipService);
   }
   
   private void aNewInstanceGetsRingInfo(GossipSettings settings) throws UnknownHostException, InterruptedException, URISyntaxException {

--- a/gossip-base/src/test/java/org/apache/gossip/manager/UserDataPersistenceTest.java
+++ b/gossip-base/src/test/java/org/apache/gossip/manager/UserDataPersistenceTest.java
@@ -68,8 +68,8 @@ public class UserDataPersistenceTest {
       gossipService.init();
       Assert.assertEquals("red", ((AToothpick) gossipService.findPerNodeGossipData(nodeId, "a").getPayload()).getColor());
       Assert.assertEquals("blue", ((AToothpick) gossipService.findSharedGossipData("a").getPayload()).getColor());
-      File f = gossipService.getUserDataState().computeSharedTarget();
-      File g = gossipService.getUserDataState().computePerNodeTarget();
+      File f = GossipManager.buildSharedDataPath(gossipService);
+      File g = GossipManager.buildPerNodeDataPath(gossipService);
       gossipService.shutdown();
       f.delete();
       g.delete();

--- a/gossip-base/src/test/java/org/apache/gossip/manager/handlers/MessageHandlerTest.java
+++ b/gossip-base/src/test/java/org/apache/gossip/manager/handlers/MessageHandlerTest.java
@@ -64,7 +64,7 @@ public class MessageHandlerTest {
       return true;
     }
   }
-
+      
   @Test
   public void testSimpleHandler() {
     MessageHandler mi = new TypedMessageHandler(FakeMessage.class, new FakeMessageHandler());


### PR DESCRIPTION
With these changes, it should now be possible to create alternate serialization (e.g. Gson or native) and transports (like HTTP).

To make this PR reviewable I decided against creating new modules right now. That can be done subsequently in another PR that doesn't modify any code.

* Creates two new interfaces: `TransportManager` and `ProtocolManager`
  * Implementation classes must honor a common constructor interface
* Includes UDP and Jackson implementations of those.
* `AbstractTransportManager` has a lot of boilerplate that includes:
  * starting the active gossiper, and
  * starting the passive gossiper.
* Gets rid of `OnlyProcessReceivedPassiveGossipThread` as it wasn't adding anything to `PassiveGossipThread`

I spent some time trying to make the service implementations less dependent on references to `GossipManager`. There is a lot of room for improvement.
